### PR TITLE
formatRecords check fieldmapping inverted

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -104,19 +104,29 @@ class Service
                 $data = $sobj->fields;
                 $data->Id = $sobj->Id;
                 $out = [];
-                foreach ($data as $key => $value) {
-                    if (!$value instanceof SObject) {
-                        if (isset($this->fieldMap[$key])) {
-                            $out[$this->fieldMap[$key]] = $value;
-                        }
+
+                foreach($this->fieldMap as $salesForceField => $mapField)     {
+
+                    $fieldParts = explode('.', $salesForceField);
+
+                    // check field exists
+                    if (!$data->{$fieldParts[0]}) {
+                        $out[$mapField] = NULL;
                         continue;
                     }
-                    // joined fields (Owner.Name, Owner.Email)
-                    foreach ($value->fields as $subkey => $subvalue) {
-                        $complexKey = $key . '.' . $subkey;
-                        if (isset($this->fieldMap[$complexKey])) {
-                            $out[$this->fieldMap[$complexKey]] = $subvalue;
+
+
+                    if ($data->{$fieldParts[0]} instanceof SObject) {
+                        // joined fields (Owner.Name, Owner.Email)
+                        $key = $fieldParts[0];
+                        foreach ($data->{$key}->fields as $subkey => $subvalue) {
+                            $complexKey = $key . '.' . $subkey;
+                            if (isset($this->fieldMap[$complexKey])) {
+                                $out[$this->fieldMap[$complexKey]] = $subvalue;
+                            }
                         }
+                    } else {
+                        $out[$mapField] = $data->{$fieldParts[0]};
                     }
                 }
                 return $out;


### PR DESCRIPTION
Before the check was if a field exists in the response data then it was listed in out and from that the insert query is build, but when the first row did not have the field the insert values where not build and therefore the column count didn't match.

The check if a field exists was inverted.